### PR TITLE
Lower the required version of Net::Async::SMTP

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,6 @@ requires 'Plack::Handler::Net::Async::HTTP::Server';
 requires 'Net::Async::HTTP';
 requires 'IO::Async::SSL';
 requires 'Router::Simple';
-requires 'Net::Async::SMTP' => '0.003';
+requires 'Net::Async::SMTP' => '0.002';
 requires 'Text::Xslate';
 


### PR DESCRIPTION
Version 0.003 doesn't exist in CPAN nor BackPAN, but 0.002 does.